### PR TITLE
Rebase against upstream/master

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
     depends_on:
       - package_lambda
     plugins:
-      - artifacts#v1.9.0:
+      - artifacts#v1.9.4:
           download:
             - build/lambda.zip
 
@@ -36,6 +36,6 @@ steps:
     depends_on:
       - package_lambda
     plugins:
-      - artifacts#v1.9.0:
+      - artifacts#v1.9.4:
           download:
             - build/lambda.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,30 +1,37 @@
 steps:
-  - label: ':s3: Upload it to S3 (hetest)'
+  - label: ':package: :lambda: Lambda'
     agents:
       docker: 'true'
+      queue: build
+    artifact_paths:
+      - build/lambda.zip
     branches: master test-*
-    concurrency: 1
-    commands: 
+    commands:
       - make all
-      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/deploy-hetest
-    key: deploy_test
-    plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
-          role: arn:aws:iam::530261158904:role/buildkite-$BUILDKITE_PIPELINE_SLUG
+    key: package_lambda
 
-  - label: ':s3: Upload it to S3 (heaws)'
+  - label: ':s3: Upload Lambda to S3 (hetest)'
     agents:
-      docker: 'true'
-    branches: master
-    concurrency: 1
-    commands: 
-      - make all
-      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/deploy-heaws
+      queue: test1
+    branches: master test-*
+    commands:
+      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
-      - deploy_test
-    key: deploy_prod
+      - package_lambda
     plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
-          role: arn:aws:iam::340978087534:role/buildkite-$BUILDKITE_PIPELINE_SLUG
+      - artifacts#v1.9.0:
+          download:
+            - build/lambda.zip
+
+  - label: ':s3: Upload Lambda to S3 (heaws)'
+    agents:
+      queue: prod1
+    branches: master
+    commands:
+      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    depends_on:
+      - package_lambda
+    plugins:
+      - artifacts#v1.9.0:
+          download:
+            - build/lambda.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,30 @@
+steps:
+  - label: ':s3: Upload it to S3 (hetest)'
+    agents:
+      docker: 'true'
+    branches: master test-*
+    concurrency: 1
+    commands: 
+      - make all
+      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    concurrency_group: $BUILDKITE_PIPELINE_SLUG/deploy-hetest
+    key: deploy_test
+    plugins:
+      - cultureamp/aws-assume-role#v0.1.0:
+          role: arn:aws:iam::530261158904:role/buildkite-$BUILDKITE_PIPELINE_SLUG
+
+  - label: ':s3: Upload it to S3 (heaws)'
+    agents:
+      docker: 'true'
+    branches: master
+    concurrency: 1
+    commands: 
+      - make all
+      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    concurrency_group: $BUILDKITE_PIPELINE_SLUG/deploy-heaws
+    depends_on:
+      - deploy_test
+    key: deploy_prod
+    plugins:
+      - cultureamp/aws-assume-role#v0.1.0:
+          role: arn:aws:iam::340978087534:role/buildkite-$BUILDKITE_PIPELINE_SLUG

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,19 +3,24 @@ steps:
     agents:
       docker: 'true'
       queue: build
+    branches: '!master !test-*'
+    command: make all
+
+  - label: ':package: :lambda: Lambda'
+    agents:
+      docker: 'true'
+      queue: build
     artifact_paths:
       - build/lambda.zip
     branches: master test-*
-    commands:
-      - make all
+    command: make all
     key: package_lambda
 
   - label: ':s3: Upload Lambda to S3 (hetest)'
     agents:
       queue: test1
     branches: master test-*
-    commands:
-      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    command: aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
       - package_lambda
     plugins:
@@ -27,8 +32,7 @@ steps:
     agents:
       queue: prod1
     branches: master
-    commands:
-      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    command: aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
       - package_lambda
     plugins:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @HealthEngineAU/sre

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN yum install -y cpio wget
 
 # Set up working directories
 RUN mkdir -p /opt/app/bin/
+RUN mkdir -p /opt/app/python_modules
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,15 @@ RUN mkdir -p /opt/app/bin/
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN wget https://www.clamav.net/downloads/production/clamav-${clamav_version}.linux.x86_64.rpm -O clamav.rpm -U "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0" --no-verbose
+RUN wget https://www.clamav.net/downloads/production/clamav-${clamav_version}.linux.x86_64.deb -O clamav.deb -U "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0" --no-verbose
 
-RUN rpm2cpio clamav.rpm | cpio -idmv
+RUN dpkg-deb -R clamav.deb /tmp
 
 # Copy over the binaries and libraries
 RUN cp -r /tmp/usr/local/bin/clamdscan \
        /tmp/usr/local/sbin/clamd \
        /tmp/usr/local/bin/freshclam \
-       /tmp/usr/local/lib64/* \
+       /tmp/usr/local/lib/lib* \
        /opt/app/bin/
 
 RUN echo "DatabaseDirectory /tmp/clamav_defs" > /opt/app/bin/scan.conf

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ the table below for reference.
 | DATADOG_API_KEY | API Key for pushing metrics to DataDog (optional)                                               | | No |
 | AV_PROCESS_ORIGINAL_VERSION_ONLY | Controls that only original version of an S3 key is processed (if bucket versioning is enabled) | False | No |
 | AV_DELETE_INFECTED_FILES | Controls whether infected files should be automatically deleted                                 | False | No |
-| EVENT_SOURCE | The source of antivirus scan event "S3" or "SNS" (optional)                                     | S3 | No |
+| EVENT_SOURCE | The source of antivirus scan event "S3", "SNS" or "S3-BATCH" (optional)                         | S3 | No |
 | AV_EFS_MOUNT_POINT | EFS mount point that used to scan larger files that does not fit lambda's storage (optional)    | | No |
 
 ## S3 Bucket Policy Examples

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ Scan new objects added to any s3 bucket using AWS Lambda. [more details in this 
 
 This was forked from https://github.com/wiley/bucket-antivirus-function
 
-The upstream project hasn't been updated in quite a while and still expects a Python 3.7 environment that AWS has deprecated.
-Our fork has been updated to work with Python 3.9
-
 ### SSL CA Certificate
 
 By default the `freshclam` binary is looking for `/etc/ssl/certs/ca-certificates.crt` which does not exist in the AWS Lambda environment.
@@ -16,23 +13,18 @@ Therefore `freshclam` will fail to download virus definition updates since it do
 
 The `certifi` Python module defined in `requirements.txt` contains a CA certificate bundle.
 The fix is to make sure the Lambda is deployed with the `CURL_CA_BUNDLE` environment variable set to `/var/task/certifi/cacert.pem`
+We do this in the `k8s` repository that deploys the ZIP file produced by this repository.
 
-NOTE: Your Lambda ZIP gets unpack in the `/var/task/` directory.
+NOTE: Your Lambda ZIP gets unpacked in the `/var/task/` directory.
 
 ### Improvements
 
 If it turns out that the upstream project is never going to be updated and we need to maintain this fork forever then the following improvements can be made.
 
 - All the hacks that adjust `LD_LIBRARY_PATH` in `clamav.py` should be removed.
-Then the `Dockerfile` should be changed so that the libraries that get unpacked to `/tmp/usr/local/lib/lib*` end up in a
+Then the `Dockerfile` should be changed so that the libraries that get unpacked, end up in a
 top-level `/lib` directory in the ZIP file instead of being below `/bin`.
 The AWS Lambda environment includes `/var/task/lib` in its `LD_LIBRARY_PATH`.
-
-- To go beyond Python 3.9 it might be a case of just needing to make sure the modules are `requirements.txt` are updated.
-With the current versions of the modules newer Python versions result in the following error:
-```
-[ERROR] Runtime.ImportModuleError: Unable to import module 'scan': cannot import name 'Iterable' from 'collections' (/var/lang/lib/python3.11/collections/__init__.py)
-```
 
 ## Features
 

--- a/clamav.py
+++ b/clamav.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Upside Travel, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,33 +14,32 @@
 # limitations under the License.
 
 import datetime
-import errno
 import hashlib
 import os
 import pwd
-import socket
+import re
 import subprocess
+import socket
+import errno
 
 import boto3
 import botocore
 
-from common import (
-    AV_DEFINITION_FILE_PREFIXES,
-    AV_DEFINITION_FILE_SUFFIXES,
-    AV_DEFINITION_PATH,
-    AV_DEFINITION_S3_BUCKET,
-    AV_DEFINITION_S3_PREFIX,
-    AV_SIGNATURE_OK,
-    AV_SIGNATURE_UNKNOWN,
-    AV_STATUS_CLEAN,
-    AV_STATUS_INFECTED,
-    CLAMAVLIB_PATH,
-    CLAMD_SOCKET,
-    CLAMDSCAN_PATH,
-    CLAMDSCAN_TIMEOUT,
-    FRESHCLAM_PATH,
-    create_dir,
-)
+from common import AV_DEFINITION_S3_BUCKET
+from common import AV_DEFINITION_S3_PREFIX
+from common import AV_DEFINITION_PATH
+from common import AV_DEFINITION_FILE_PREFIXES
+from common import AV_DEFINITION_FILE_SUFFIXES
+from common import AV_SIGNATURE_OK
+from common import AV_SIGNATURE_UNKNOWN
+from common import AV_STATUS_CLEAN
+from common import AV_STATUS_INFECTED
+from common import CLAMAVLIB_PATH
+from common import CLAMDSCAN_PATH
+from common import FRESHCLAM_PATH
+from common import CLAMDSCAN_TIMEOUT
+from common import create_dir
+from common import CLAMD_SOCKET
 
 
 def update_defs_from_s3(s3_client, bucket, prefix):
@@ -57,7 +57,8 @@ def update_defs_from_s3(s3_client, bucket, prefix):
             if s3_best_time is not None and s3_time < s3_best_time:
                 print("Not downloading older file in series: %s" % filename)
                 continue
-            s3_best_time = s3_time
+            else:
+                s3_best_time = s3_time
 
             if os.path.exists(local_path) and md5_from_file(local_path) == s3_md5:
                 print("Not downloading %s because local md5 matches s3." % filename)
@@ -77,8 +78,13 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
             local_file_path = os.path.join(local_path, filename)
             if os.path.exists(local_file_path):
                 local_file_md5 = md5_from_file(local_file_path)
-                if local_file_md5 != md5_from_s3_tags(s3_client, bucket, os.path.join(prefix, filename)):
-                    print("Uploading %s to s3://%s" % (local_file_path, os.path.join(bucket, prefix, filename)))
+                if local_file_md5 != md5_from_s3_tags(
+                    s3_client, bucket, os.path.join(prefix, filename)
+                ):
+                    print(
+                        "Uploading %s to s3://%s"
+                        % (local_file_path, os.path.join(bucket, prefix, filename))
+                    )
                     s3 = boto3.resource("s3")
                     s3_object = s3.Object(bucket, os.path.join(prefix, filename))
                     s3_object.upload_file(os.path.join(local_path, filename))
@@ -88,7 +94,10 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
                         Tagging={"TagSet": [{"Key": "md5", "Value": local_file_md5}]},
                     )
                 else:
-                    print("Not uploading %s because md5 on remote matches local." % filename)
+                    print(
+                        "Not uploading %s because md5 on remote matches local."
+                        % filename
+                    )
             else:
                 print("File does not exist: %s" % filename)
 
@@ -137,7 +146,8 @@ def md5_from_s3_tags(s3_client, bucket, key):
         }
         if e.response["Error"]["Code"] in expected_errors:
             return ""
-        raise
+        else:
+            raise
     for tag in tags:
         if tag["Key"] == "md5":
             return tag["Value"]
@@ -151,7 +161,8 @@ def time_from_s3(s3_client, bucket, key):
         expected_errors = {"404", "AccessDenied", "NoSuchKey"}
         if e.response["Error"]["Code"] in expected_errors:
             return datetime.datetime.fromtimestamp(0, datetime.UTC)
-        raise
+        else:
+            raise
     return time
 
 
@@ -194,18 +205,19 @@ def scan_file(path):
 
     if av_proc.returncode == 0:
         return AV_STATUS_CLEAN, AV_SIGNATURE_OK
-    if av_proc.returncode == 1:
+    elif av_proc.returncode == 1:
         # Turn the output into a data source we can read
         summary = scan_output_to_json(decoded_output)
         signature = summary.get(path, AV_SIGNATURE_UNKNOWN)
         return AV_STATUS_INFECTED, signature
-    msg = "Unexpected exit code from clamdscan: %s.\n" % av_proc.returncode
+    else:
+        msg = "Unexpected exit code from clamdscan: %s.\n" % av_proc.returncode
 
-    if errors:
-        msg += "Errors: %s\n" % errors.decode()
+        if errors:
+            msg += "Errors: %s\n" % errors.decode()
 
-    print(msg)
-    raise Exception(msg)
+        print(msg)
+        raise Exception(msg)
 
 
 def is_clamd_running():
@@ -218,7 +230,7 @@ def is_clamd_running():
                 s.connect(CLAMD_SOCKET)
                 s.send(b"PING")
                 data = s.recv(32)
-            except (TimeoutError, OSError) as e:
+            except (socket.timeout, socket.error) as e:
                 print("Failed to read from socket: %s\n" % e)
                 return False
 
@@ -233,7 +245,9 @@ def start_clamd_daemon():
     s3 = boto3.resource("s3")
     s3_client = boto3.client("s3")
 
-    to_download = update_defs_from_s3(s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
+    to_download = update_defs_from_s3(
+        s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX
+    )
 
     for download in to_download.values():
         s3_path = download["s3_path"]

--- a/clamav.py
+++ b/clamav.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Upside Travel, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,32 +13,33 @@
 # limitations under the License.
 
 import datetime
+import errno
 import hashlib
 import os
 import pwd
-import re
-import subprocess
 import socket
-import errno
+import subprocess
 
 import boto3
 import botocore
 
-from common import AV_DEFINITION_S3_BUCKET
-from common import AV_DEFINITION_S3_PREFIX
-from common import AV_DEFINITION_PATH
-from common import AV_DEFINITION_FILE_PREFIXES
-from common import AV_DEFINITION_FILE_SUFFIXES
-from common import AV_SIGNATURE_OK
-from common import AV_SIGNATURE_UNKNOWN
-from common import AV_STATUS_CLEAN
-from common import AV_STATUS_INFECTED
-from common import CLAMAVLIB_PATH
-from common import CLAMDSCAN_PATH
-from common import FRESHCLAM_PATH
-from common import CLAMDSCAN_TIMEOUT
-from common import create_dir
-from common import CLAMD_SOCKET
+from common import (
+    AV_DEFINITION_FILE_PREFIXES,
+    AV_DEFINITION_FILE_SUFFIXES,
+    AV_DEFINITION_PATH,
+    AV_DEFINITION_S3_BUCKET,
+    AV_DEFINITION_S3_PREFIX,
+    AV_SIGNATURE_OK,
+    AV_SIGNATURE_UNKNOWN,
+    AV_STATUS_CLEAN,
+    AV_STATUS_INFECTED,
+    CLAMAVLIB_PATH,
+    CLAMD_SOCKET,
+    CLAMDSCAN_PATH,
+    CLAMDSCAN_TIMEOUT,
+    FRESHCLAM_PATH,
+    create_dir,
+)
 
 
 def update_defs_from_s3(s3_client, bucket, prefix):
@@ -57,8 +57,7 @@ def update_defs_from_s3(s3_client, bucket, prefix):
             if s3_best_time is not None and s3_time < s3_best_time:
                 print("Not downloading older file in series: %s" % filename)
                 continue
-            else:
-                s3_best_time = s3_time
+            s3_best_time = s3_time
 
             if os.path.exists(local_path) and md5_from_file(local_path) == s3_md5:
                 print("Not downloading %s because local md5 matches s3." % filename)
@@ -78,13 +77,8 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
             local_file_path = os.path.join(local_path, filename)
             if os.path.exists(local_file_path):
                 local_file_md5 = md5_from_file(local_file_path)
-                if local_file_md5 != md5_from_s3_tags(
-                    s3_client, bucket, os.path.join(prefix, filename)
-                ):
-                    print(
-                        "Uploading %s to s3://%s"
-                        % (local_file_path, os.path.join(bucket, prefix, filename))
-                    )
+                if local_file_md5 != md5_from_s3_tags(s3_client, bucket, os.path.join(prefix, filename)):
+                    print("Uploading %s to s3://%s" % (local_file_path, os.path.join(bucket, prefix, filename)))
                     s3 = boto3.resource("s3")
                     s3_object = s3.Object(bucket, os.path.join(prefix, filename))
                     s3_object.upload_file(os.path.join(local_path, filename))
@@ -94,10 +88,7 @@ def upload_defs_to_s3(s3_client, bucket, prefix, local_path):
                         Tagging={"TagSet": [{"Key": "md5", "Value": local_file_md5}]},
                     )
                 else:
-                    print(
-                        "Not uploading %s because md5 on remote matches local."
-                        % filename
-                    )
+                    print("Not uploading %s because md5 on remote matches local." % filename)
             else:
                 print("File does not exist: %s" % filename)
 
@@ -146,8 +137,7 @@ def md5_from_s3_tags(s3_client, bucket, key):
         }
         if e.response["Error"]["Code"] in expected_errors:
             return ""
-        else:
-            raise
+        raise
     for tag in tags:
         if tag["Key"] == "md5":
             return tag["Value"]
@@ -161,8 +151,7 @@ def time_from_s3(s3_client, bucket, key):
         expected_errors = {"404", "AccessDenied", "NoSuchKey"}
         if e.response["Error"]["Code"] in expected_errors:
             return datetime.datetime.fromtimestamp(0, datetime.UTC)
-        else:
-            raise
+        raise
     return time
 
 
@@ -205,19 +194,18 @@ def scan_file(path):
 
     if av_proc.returncode == 0:
         return AV_STATUS_CLEAN, AV_SIGNATURE_OK
-    elif av_proc.returncode == 1:
+    if av_proc.returncode == 1:
         # Turn the output into a data source we can read
         summary = scan_output_to_json(decoded_output)
         signature = summary.get(path, AV_SIGNATURE_UNKNOWN)
         return AV_STATUS_INFECTED, signature
-    else:
-        msg = "Unexpected exit code from clamdscan: %s.\n" % av_proc.returncode
+    msg = "Unexpected exit code from clamdscan: %s.\n" % av_proc.returncode
 
-        if errors:
-            msg += "Errors: %s\n" % errors.decode()
+    if errors:
+        msg += "Errors: %s\n" % errors.decode()
 
-        print(msg)
-        raise Exception(msg)
+    print(msg)
+    raise Exception(msg)
 
 
 def is_clamd_running():
@@ -230,7 +218,7 @@ def is_clamd_running():
                 s.connect(CLAMD_SOCKET)
                 s.send(b"PING")
                 data = s.recv(32)
-            except (socket.timeout, socket.error) as e:
+            except (TimeoutError, OSError) as e:
                 print("Failed to read from socket: %s\n" % e)
                 return False
 
@@ -245,9 +233,7 @@ def start_clamd_daemon():
     s3 = boto3.resource("s3")
     s3_client = boto3.client("s3")
 
-    to_download = update_defs_from_s3(
-        s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX
-    )
+    to_download = update_defs_from_s3(s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
 
     for download in to_download.values():
         s3_path = download["s3_path"]

--- a/scan.py
+++ b/scan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Upside Travel, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,36 +14,38 @@
 
 import copy
 import json
+import logging
 import os
 import signal
-import psutil
 import traceback
 import uuid
-import logging
 from urllib.parse import unquote_plus
-from common import strtobool
+
+import boto3
+import psutil
 from kafka import KafkaProducer
 from kafka.errors import KafkaError
 
-import boto3
-
 import clamav
-from common import AV_DELETE_INFECTED_FILES
-from common import AV_PROCESS_ORIGINAL_VERSION_ONLY
-from common import AV_SCAN_START_METADATA
-from common import REX_KAFKA_BOOTSTRAP_SERVERS
-from common import AV_SCAN_START_TOPIC
-from common import AV_SIGNATURE_METADATA
-from common import AV_STATUS_CLEAN
-from common import AV_STATUS_INFECTED
-from common import AV_STATUS_METADATA
-from common import REX_KAFKA_TOPIC_AVSCAN_RESPONSE
-from common import AV_STATUS_PUBLISH_CLEAN
-from common import AV_STATUS_PUBLISH_INFECTED
-from common import AV_TIMESTAMP_METADATA
-from common import AV_EFS_MOUNT_POINT
-from common import create_dir
-from common import get_timestamp
+from common import (
+    AV_DELETE_INFECTED_FILES,
+    AV_EFS_MOUNT_POINT,
+    AV_PROCESS_ORIGINAL_VERSION_ONLY,
+    AV_SCAN_START_METADATA,
+    AV_SCAN_START_TOPIC,
+    AV_SIGNATURE_METADATA,
+    AV_STATUS_CLEAN,
+    AV_STATUS_INFECTED,
+    AV_STATUS_METADATA,
+    AV_STATUS_PUBLISH_CLEAN,
+    AV_STATUS_PUBLISH_INFECTED,
+    AV_TIMESTAMP_METADATA,
+    REX_KAFKA_BOOTSTRAP_SERVERS,
+    REX_KAFKA_TOPIC_AVSCAN_RESPONSE,
+    create_dir,
+    get_timestamp,
+    strtobool,
+)
 
 DEFAULT_SCAN_DIR = "/tmp"
 clamd_pid = None
@@ -59,11 +60,12 @@ for handler in logger.handlers:
 
 stream_handler = logging.StreamHandler()
 
-formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
 stream_handler.setFormatter(formatter)
 
 logger.addHandler(stream_handler)
 logger.setLevel(logging.INFO)
+
 
 def get_kafka_producer():
     """Get or create a Kafka producer instance that persists across invocations."""
@@ -77,29 +79,41 @@ def get_kafka_producer():
     if kafka_producer is None:
         try:
             kafka_producer = KafkaProducer(
-                bootstrap_servers=REX_KAFKA_BOOTSTRAP_SERVERS.split(','),
-                security_protocol='PLAINTEXT',
-                api_version = (3, 5, 1),
-                value_serializer=lambda v: json.dumps(v).encode('utf-8'),
+                bootstrap_servers=REX_KAFKA_BOOTSTRAP_SERVERS.split(","),
+                security_protocol="PLAINTEXT",
+                api_version=(3, 5, 1),
+                value_serializer=lambda v: json.dumps(v).encode("utf-8"),
                 # Add some sensible defaults for Lambda environment
                 request_timeout_ms=30000,
                 retry_backoff_ms=500,
                 max_in_flight_requests_per_connection=1,
-                acks='all'
+                acks="all",
             )
             logging.info("Created new Kafka producer")
         except Exception as e:
-            logging.error(f"Failed to create Kafka producer: {e}")
+            logging.exception(f"Failed to create Kafka producer: {e}")
             traceback.print_exc()
             return None
     return kafka_producer
 
 
 def event_object(event, event_source="s3"):
+    s3 = boto3.resource("s3")
 
     # SNS events are slightly different
     if event_source.upper() == "SNS":
         event = json.loads(event["Records"][0]["Sns"]["Message"])
+
+    if event_source.upper() == "S3-BATCH":
+        task = event["tasks"][0]
+        bucket_arn = task["s3BucketArn"]
+        key_name = task["s3Key"]
+
+        bucket_name = bucket_arn.split(":")[-1]
+
+        key_name = unquote_plus(key_name)
+
+        return s3.Object(bucket_name, key_name)
 
     # Break down the record
     records = event["Records"]
@@ -124,10 +138,8 @@ def event_object(event, event_source="s3"):
 
     # Ensure both bucket and key exist
     if (not bucket_name) or (not key_name):
-        raise Exception("Unable to retrieve object from event.\n{}".format(event))
+        raise Exception(f"Unable to retrieve object from event.\n{event}")
 
-    # Create and return the object
-    s3 = boto3.resource("s3")
     return s3.Object(bucket_name, key_name)
 
 
@@ -147,9 +159,7 @@ def verify_s3_object_version(s3, s3_object):
             )
     else:
         # misconfigured bucket, left with no or suspended versioning
-        raise Exception(
-            "Object versioning is not enabled in bucket %s" % s3_object.bucket_name
-        )
+        raise Exception("Object versioning is not enabled in bucket %s" % s3_object.bucket_name)
 
 
 def get_local_path(s3_object):
@@ -177,10 +187,7 @@ def delete_s3_object(s3_object):
     try:
         s3_object.delete()
     except Exception:
-        raise Exception(
-            "Failed to delete infected file: %s.%s"
-            % (s3_object.bucket_name, s3_object.key)
-        )
+        raise Exception("Failed to delete infected file: %s.%s" % (s3_object.bucket_name, s3_object.key))
     else:
         print("Infected file deleted: %s.%s" % (s3_object.bucket_name, s3_object.key))
 
@@ -202,9 +209,7 @@ def set_av_metadata(s3_object, scan_result, scan_signature, timestamp):
 
 
 def set_av_tags(s3_client, s3_object, scan_result, scan_signature, timestamp):
-    curr_tags = s3_client.get_object_tagging(
-        Bucket=s3_object.bucket_name, Key=s3_object.key
-    )["TagSet"]
+    curr_tags = s3_client.get_object_tagging(Bucket=s3_object.bucket_name, Key=s3_object.key)["TagSet"]
     new_tags = copy.copy(curr_tags)
     for tag in curr_tags:
         if tag["Key"] in [
@@ -216,9 +221,7 @@ def set_av_tags(s3_client, s3_object, scan_result, scan_signature, timestamp):
     new_tags.append({"Key": AV_SIGNATURE_METADATA, "Value": scan_signature})
     new_tags.append({"Key": AV_STATUS_METADATA, "Value": scan_result})
     new_tags.append({"Key": AV_TIMESTAMP_METADATA, "Value": timestamp})
-    s3_client.put_object_tagging(
-        Bucket=s3_object.bucket_name, Key=s3_object.key, Tagging={"TagSet": new_tags}
-    )
+    s3_client.put_object_tagging(Bucket=s3_object.bucket_name, Key=s3_object.key, Tagging={"TagSet": new_tags})
 
 
 def kafka_start_scan(producer, s3_object, scan_start_topic, timestamp):
@@ -233,25 +236,18 @@ def kafka_start_scan(producer, s3_object, scan_start_topic, timestamp):
         producer.send(scan_start_topic, message)
         producer.flush()
     except KafkaError as e:
-        logging.error(f"Failed to send Kafka start scan message: {e}")
+        logging.exception(f"Failed to send Kafka start scan message: {e}")
 
 
-def kafka_scan_results(
-    producer, s3_object, scan_result, scan_signature, timestamp
-):
+def kafka_scan_results(producer, s3_object, scan_result, scan_signature, timestamp):
     # Don't publish if scan_result is CLEAN and CLEAN results should not be published
     if scan_result == AV_STATUS_CLEAN and not str_to_bool(AV_STATUS_PUBLISH_CLEAN):
         return
     # Don't publish if scan_result is INFECTED and INFECTED results should not be published
-    if scan_result == AV_STATUS_INFECTED and not str_to_bool(
-        AV_STATUS_PUBLISH_INFECTED
-    ):
+    if scan_result == AV_STATUS_INFECTED and not str_to_bool(AV_STATUS_PUBLISH_INFECTED):
         return
-    message_key = str(uuid.uuid4()).encode('utf-8')
-    headers = [
-        ('bucket', s3_object.bucket_name.encode('utf-8')),
-        ('transactionId', message_key)
-    ]
+    message_key = str(uuid.uuid4()).encode("utf-8")
+    headers = [("bucket", s3_object.bucket_name.encode("utf-8")), ("transactionId", message_key)]
     message = {
         "key": s3_object.key,
         "version": s3_object.version_id,
@@ -260,11 +256,13 @@ def kafka_scan_results(
         AV_TIMESTAMP_METADATA: get_timestamp(),
     }
     try:
-        logging.info(f"Sending message to topic {REX_KAFKA_TOPIC_AVSCAN_RESPONSE} with key={message_key} and headers={headers} and value= {message}")
+        logging.info(
+            f"Sending message to topic {REX_KAFKA_TOPIC_AVSCAN_RESPONSE} with key={message_key} and headers={headers} and value= {message}"
+        )
         producer.send(REX_KAFKA_TOPIC_AVSCAN_RESPONSE, key=message_key, value=message, headers=headers)
         producer.flush()
     except KafkaError as e:
-        logging.error(f"Failed to send Kafka scan results message: {e}")
+        logging.exception(f"Failed to send Kafka scan results message: {e}")
 
 
 def kill_process_by_pid(pid):
@@ -306,9 +304,7 @@ def lambda_handler(event, context):
     print("Script starting at %s\n" % (start_time))
     s3_object = event_object(event, event_source=EVENT_SOURCE)
 
-    print(
-        "Scanning s3://%s ...\n" % (os.path.join(s3_object.bucket_name, s3_object.key))
-    )
+    print("Scanning s3://%s ...\n" % (os.path.join(s3_object.bucket_name, s3_object.key)))
 
     if str_to_bool(AV_PROCESS_ORIGINAL_VERSION_ONLY):
         verify_s3_object_version(s3, s3_object)
@@ -324,10 +320,7 @@ def lambda_handler(event, context):
         s3_object.download_file(file_path)
 
         scan_result, scan_signature = clamav.scan_file(file_path)
-        print(
-            "Scan of s3://%s resulted in %s\n"
-            % (os.path.join(s3_object.bucket_name, s3_object.key), scan_result)
-        )
+        print("Scan of s3://%s resulted in %s\n" % (os.path.join(s3_object.bucket_name, s3_object.key), scan_result))
 
         result_time = get_timestamp()
         # Set the properties on the object with the scan results
@@ -358,6 +351,20 @@ def lambda_handler(event, context):
 
         # Don't close Kafka producer - let it persist for future invocations
         # It will be reused by subsequent Lambda invocations for better performance
+
+    if EVENT_SOURCE.upper() == "S3-BATCH":
+        return {
+            "invocationSchemaVersion": event["invocationSchemaVersion"],
+            "treatMissingKeysAs": "PermanentFailure",
+            "invocationId": event["invocationId"],
+            "results": [
+                {
+                    "taskId": event["tasks"][0]["taskId"],
+                    "resultCode": "Succeeded",
+                    "resultString": scan_result,
+                }
+            ],
+        }
 
 
 def str_to_bool(s):


### PR DESCRIPTION
The upstream has updated things to Python 3.12.
Therefore rebase this to match their updates.

As part of that, ditch all our custom Docker changes and just use the
Dockerfile that upstream is using except the FROM statements since they
use a private repository that I think is a mirror.

Update the Buildkite plugins.

Tweak our README.md changes to match the new state of play.

The only code differences between us and upstream is in scan.py where
we introduced an `S3-BATCH` event source.
